### PR TITLE
Fix: Replace sound.exists with sound.get

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -46,7 +46,7 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
                 bullet.setVisible(true);
                 // The bullet's constructor and physics should handle its movement.
                 this.lastFired = this.scene.time.now;
-                if (this.scene.sound.exists('sfx_player_shoot')) {
+                if (this.scene.sound.get('sfx_player_shoot')) {
                     this.scene.sound.play('sfx_player_shoot'); // Play shoot sound
                 }
             }

--- a/src/game.ts
+++ b/src/game.ts
@@ -141,7 +141,7 @@ function startGame(this: Phaser.Scene) {
     startNextWave.call(this); // Start the first wave
 
     // Start background music
-    if (this.sound.exists(MUSIC_BACKGROUND)) {
+    if (this.sound.get(MUSIC_BACKGROUND)) {
         if (!this.sound.get(MUSIC_BACKGROUND) || !this.sound.get(MUSIC_BACKGROUND).isPlaying) {
             this.sound.play(MUSIC_BACKGROUND, { loop: true, volume: 0.5 });
         } else if (this.sound.get(MUSIC_BACKGROUND).isPaused) { 
@@ -194,7 +194,7 @@ function handleBulletEnemyCollision(this: Phaser.Scene, bullet: Phaser.GameObjec
     enemy.destroy();
     score += 10;
     scoreText.setText('Score: ' + score);
-    if (this.sound.exists(SFX_ENEMY_HIT)) {
+    if (this.sound.get(SFX_ENEMY_HIT)) {
         this.sound.play(SFX_ENEMY_HIT);
     }
 }
@@ -205,7 +205,7 @@ function handlePlayerHitByEnemyBullet(this: Phaser.Scene, playerObj: Phaser.Game
     enemyBullet.destroy();
     lives--;
     livesText.setText('Lives: ' + lives);
-    if (this.sound.exists(SFX_PLAYER_HIT)) {
+    if (this.sound.get(SFX_PLAYER_HIT)) {
         this.sound.play(SFX_PLAYER_HIT);
     }
     console.log('Player hit! Lives left: ' + lives);
@@ -214,7 +214,7 @@ function handlePlayerHitByEnemyBullet(this: Phaser.Scene, playerObj: Phaser.Game
         isGameOver = true;
         console.log('Game Over');
         (playerObj as Player).setActive(false).setVisible(false);
-        if (this.sound.exists(MUSIC_BACKGROUND)) { // Guard stopping music as well
+        if (this.sound.get(MUSIC_BACKGROUND)) { // Guard stopping music as well
             this.sound.stopByKey(MUSIC_BACKGROUND); 
         }
 


### PR DESCRIPTION
The `sound.exists` method is not available on all possible sound manager types in the version of Phaser being used, leading to a TypeScript compilation error. This change replaces the usage of `sound.exists` with `sound.get`, which correctly checks for the presence of a loaded sound before attempting to play it. This resolves the compilation errors.